### PR TITLE
RDKB-60199 -  IDM continuously sending device capabilities causing IDM memory leak

### DIFF
--- a/source/InterDeviceManager/Idm_TCP_apis.h
+++ b/source/InterDeviceManager/Idm_TCP_apis.h
@@ -23,6 +23,9 @@
 #include "Idm_rbus.h"
 #include "Idm_msg_process.h"
 
+extern bool connect_reset;
+extern pthread_mutex_t connect_reset_mutex;
+
 int open_remote_connection(connection_config_t* connectionConf, int (*connection_cb)(device_info_t* Device, connection_info_t* conn_info, uint encryption_status), int (*rcv_message_cb)( connection_info_t* conn_info, void *payload)) ;
 
 int send_remote_message(connection_info_t* conn_info, void *payload);

--- a/source/InterDeviceManager/Idm_call_back_apis.c
+++ b/source/InterDeviceManager/Idm_call_back_apis.c
@@ -77,9 +77,10 @@ int stop_discovery();
 
 int rcv_message_cb( connection_info_t* conn_info, void *payload)
 {
-    CcspTraceInfo(("%s %d - \n", __FUNCTION__, __LINE__));
 
     payload_t *recvData = (payload_t*)payload;
+    CcspTraceInfo(("%s %d - msgType-%d \n", __FUNCTION__, __LINE__,recvData->msgType));
+
     if(recvData->msgType == REQ)
     {
         IDM_Incoming_Request_handler(recvData);
@@ -823,6 +824,11 @@ ANSC_STATUS IDM_Start_Device_Discovery()
 ANSC_STATUS IDM_Stop_Device_Discovery()
 {
     CcspTraceInfo(("%s %d - called\n", __FUNCTION__, __LINE__ ));
+
+    pthread_mutex_lock(&connect_reset_mutex);
+    connect_reset = true; //To exit any previous waiting connect  
+    pthread_mutex_unlock(&connect_reset_mutex);
+
     if(stop_discovery() !=0)
     {
         CcspTraceError(("%s %d - stop_discovery failed\n", __FUNCTION__, __LINE__));

--- a/source/InterDeviceManager/Idm_msg_process.c
+++ b/source/InterDeviceManager/Idm_msg_process.c
@@ -120,7 +120,7 @@ sendReqList* IDM_searchFromSendRequestList(const char param_mac[MAC_ADDR_SIZE])
     sendReqList *cur = headsendReqList;
     while (cur != NULL) 
     {
-        if (strncmp(cur->Mac_dest, param_mac, MAC_ADDR_SIZE - 1) == 0)
+        if (strncmp(cur->Mac_dest, param_mac, sizeof(cur->Mac_dest) - 1) == 0)
         {
             return cur;
 	}
@@ -340,7 +340,7 @@ ANSC_STATUS IDM_sendMsg_to_Remote_device(idm_send_msg_Params_t *param)
                     sendReqList *SendReq = IDM_searchFromSendRequestList(param->Mac_dest);
                     if(SendReq != NULL)
                     {
-                        CcspTraceInfo(("%s:%d IDM message already available in linked list. Resending the same request \n",__FUNCTION__, __LINE__));
+                        CcspTraceInfo(("%s:%d Resending the same request with request id %d  \n",__FUNCTION__, __LINE__,SendReq->reqId));
                         payload.reqID = SendReq->reqId; 
                     }
                     else
@@ -385,7 +385,7 @@ ANSC_STATUS IDM_sendMsg_to_Remote_device(idm_send_msg_Params_t *param)
                 usleep(250000); //Sleep for 250ms
                 if(ret != 0)
                 {
-                    CcspTraceError(("%s:%d send_remote_message failed \n",__FUNCTION__, __LINE__));
+                    CcspTraceError(("%s:%d send_remote_message failed for request id %d\n",__FUNCTION__, __LINE__,payload.reqID));
                     if(param->operation == GET || param->operation == SET || param->operation == IDM_REQUEST)
                     {
                         sendReqList *req;
@@ -534,7 +534,7 @@ int IDM_Incoming_Response_handler(payload_t * payload)
 {
     rbusMethodAsyncHandle_t async_callBack_handler;
     rbusError_t ret = RBUS_ERROR_SUCCESS;
-    CcspTraceInfo(("%s:%d operation - %d \n",__FUNCTION__, __LINE__,payload->operation));
+    CcspTraceInfo(("%s:%d operation - %d req id %d \n",__FUNCTION__, __LINE__,payload->operation, payload->reqID));
     /* find req entry in LL */
     if(payload->operation == IDM_SUBS)
     {

--- a/source/InterDeviceManager/Idm_msg_process.c
+++ b/source/InterDeviceManager/Idm_msg_process.c
@@ -109,7 +109,7 @@ sendReqList* IDM_getFromSendRequestList(uint reqID)
     }
 }
 
-sendReqList* IDM_searchFromSendRequestList(const char param_mac[MAC_ADDR_SIZE])
+sendReqList* IDM_searchFromSendRequestList(const char *param_mac)
 {
 
     if(param_mac == NULL)
@@ -394,7 +394,7 @@ ANSC_STATUS IDM_sendMsg_to_Remote_device(idm_send_msg_Params_t *param)
                         {
                             CcspTraceError(("%s:%d Request not found in SendRequestList \n",__FUNCTION__, __LINE__));
                         }else{
-                            CcspTraceInfo(("%s:%d Free allocated request from SendRequestList \n",__FUNCTION__, __LINE__));
+                            CcspTraceInfo(("%s:%d Removing request from SendRequestList \n",__FUNCTION__, __LINE__));
                             free(req);
                         }
                     }


### PR DESCRIPTION
Fix added to kill a dangling connect thread if it was not closed properly from a incomplete previous discovery.
Also fixed to prevent memory leak by not re-allocating memory for the same device capabilities multiple times.
Now for each idm request memory will be allocated only once even while re-sending.